### PR TITLE
Adding command line argument to prevent initial alerts

### DIFF
--- a/Config/configValues.go
+++ b/Config/configValues.go
@@ -1,6 +1,7 @@
 package ConfigValues
 
 import (
+    "JiraAlert/Util"
     "github.com/joho/godotenv"
     "log"
     "os"
@@ -22,6 +23,7 @@ type ConfigValues struct {
     WebhookUrlKey string
     PrometheusPort int
     PrometheusPortKey string
+    DoInitialPost     bool
 }
 
 func (cv *ConfigValues) registerKeys() {
@@ -80,6 +82,16 @@ func (cv *ConfigValues) LoadAndValidateConfig() {
     cv.PrometheusPort, err = strconv.Atoi(prometheusPortString)
     if err != nil {
         log.Fatal(cv.PrometheusPortKey + " has to be a numeric value in seconds")
+    }
+
+    log.Println("Reading command line arguments")
+    args := os.Args[:1]
+    if Util.Contains(args, "--NoInitialPost") {
+        cv.DoInitialPost = false
+        log.Println("Initial post to mattermost: disabled")
+    } else {
+        cv.DoInitialPost = true
+        log.Println("Initial post to mattermost: enabled")
     }
 }
 

--- a/Util/util.go
+++ b/Util/util.go
@@ -1,0 +1,14 @@
+package Util
+
+// https://play.golang.org/p/Qg_uv_inCek
+// contains checks if a string is present in a slice
+func Contains(s []string, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+
+	return false
+}
+

--- a/main.go
+++ b/main.go
@@ -1,18 +1,18 @@
 package main
 
 import (
-    ConfigValues "JiraAlert/Config"
-    "JiraAlert/Util"
-    "bytes"
-    "encoding/json"
-    "github.com/andygrunwald/go-jira"
-    "github.com/prometheus/client_golang/prometheus"
-    "github.com/prometheus/client_golang/prometheus/promauto"
-    "github.com/prometheus/client_golang/prometheus/promhttp"
-    "log"
-    "net/http"
-    "strconv"
-    "time"
+	ConfigValues "JiraAlert/Config"
+	"JiraAlert/Util"
+	"bytes"
+	"encoding/json"
+	"github.com/andygrunwald/go-jira"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
 )
 
 //Global Values
@@ -22,147 +22,148 @@ var markImmediatelyAsKnown bool //If set true, the next run will skip the alerti
 
 //Prometheus Metrics
 var (
-    jiraRequestDuration = promauto.NewHistogram(prometheus.HistogramOpts{
-        Name: "jiraalert_jira_request_duration",
-        Help: "The time it took to query the jira api",
-    })
+	jiraRequestDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name: "jiraalert_jira_request_duration",
+		Help: "The time it took to query the jira api",
+	})
 )
 
 var (
-    jiraCallsMade = promauto.NewCounter(prometheus.CounterOpts{
-        Name: "jiraalert_jira_calls_made",
-        Help: "The total number of requests made to the jira api",
-    })
+	jiraCallsMade = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "jiraalert_jira_calls_made",
+		Help: "The total number of requests made to the jira api",
+	})
 )
 
 var (
-    mattermostRequestDuration = promauto.NewHistogram(prometheus.HistogramOpts{
-        Name: "jiraalert_mattermost_request_duration",
-        Help: "The time it took to send the mattermost webhook request",
-    })
+	mattermostRequestDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name: "jiraalert_mattermost_request_duration",
+		Help: "The time it took to send the mattermost webhook request",
+	})
 )
 
 var (
-    mattermostCallsMade = promauto.NewCounter(prometheus.CounterOpts{
-        Name: "jiraalert_mattermost_calls_made",
-        Help: "The total number of requests made to the mattermost webhook",
-    })
+	mattermostCallsMade = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "jiraalert_mattermost_calls_made",
+		Help: "The total number of requests made to the mattermost webhook",
+	})
 )
 
 // Struct for json marshaling
 type MatterHook struct {
-    Text string
+	Text string
 }
 
 func main() {
 
-    cv = ConfigValues.ConfigValues{}
-    cv.LoadAndValidateConfig()
+	cv = ConfigValues.ConfigValues{}
+	cv.LoadAndValidateConfig()
 
-    markImmediatelyAsKnown = cv.DoInitialPost
+	markImmediatelyAsKnown = cv.DoInitialPost
 
-    log.Println("Initialize application")
-    tp := jira.BasicAuthTransport{
-        Username: cv.JiraUsername,
-        Password: cv.JiraPassword,
-    }
+	log.Println("Initialize application")
+	tp := jira.BasicAuthTransport{
+		Username: cv.JiraUsername,
+		Password: cv.JiraPassword,
+	}
 
-    client, err := jira.NewClient(tp.Client(), cv.JiraUrl)
-    if err != nil {
-        log.Fatal(err)
-    }
+	client, err := jira.NewClient(tp.Client(), cv.JiraUrl)
+	if err != nil {
+		log.Fatal(err)
+	}
 
-    filter, _, err := client.Filter.Get(cv.JiraFilterId)
+	filter, _, err := client.Filter.Get(cv.JiraFilterId)
 
-    if err != nil {
-        log.Fatal(err)
-    } else {
-        log.Println("Using filter: " + filter.Name)
-    }
+	if err != nil {
+		log.Fatal(err)
+	} else {
+		log.Println("Using filter: " + filter.Name)
+	}
 
-    log.Println("Initialize monitoring")
-    http.Handle("/metrics", promhttp.Handler())
+	log.Println("Initialize monitoring")
+	http.Handle("/metrics", promhttp.Handler())
 
-    log.Println("Start watcher")
-    finished := make(chan bool)
-    go heartBeat(finished, client, filter)
+	log.Println("Start watcher")
+	finished := make(chan bool)
+	go heartBeat(finished, client, filter)
 
-    log.Println("Starting monitoring")
-    err = http.ListenAndServe(":"+strconv.Itoa(cv.PrometheusPort), nil)
+	log.Println("Starting monitoring")
+	err = http.ListenAndServe(":"+strconv.Itoa(cv.PrometheusPort), nil)
 
-    if err != nil {
-        log.Fatal(err)
-    }
+	if err != nil {
+		log.Fatal(err)
+	}
 
-    <-finished //Wait forever ;)
+	<-finished //Wait forever ;)
 }
 
-
 func heartBeat(finished chan bool, client *jira.Client, filter *jira.Filter) {
-    for range time.Tick(time.Second * time.Duration(cv.JiraCheckInterval)) {
-        stopWatch := time.Now()
+	for range time.Tick(time.Second * time.Duration(cv.JiraCheckInterval)) {
+		stopWatch := time.Now()
 
-        issues, _, err := client.Issue.Search(filter.Jql, nil)
+		issues, _, err := client.Issue.Search(filter.Jql, nil)
 
-        stopWatchTimeElapsed := time.Since(stopWatch)
-        jiraRequestDuration.Observe(stopWatchTimeElapsed.Seconds())
+		stopWatchTimeElapsed := time.Since(stopWatch)
+		jiraRequestDuration.Observe(stopWatchTimeElapsed.Seconds())
 
-        if err != nil {
-            panic(err)
-        } else {
-            jiraCallsMade.Inc()
-        }
+		if err != nil {
+			panic(err)
+		} else {
+			jiraCallsMade.Inc()
+		}
 
-        var alerts []jira.Issue
-        prevNumberOfKnownIssues := len(knownIssues)
+		var alerts []jira.Issue
+		prevNumberOfKnownIssues := len(knownIssues)
 
-        //Check if issue is already know if not set it to alert list and mark as know
-        for _, issue := range issues {
-            if !Util.Contains(knownIssues, issue.Key) {
-                //Marks the issues as known, without writing an alert.
-                if !markImmediatelyAsKnown {
-                    alerts = append(alerts, issue)
-                } else {
-                    markImmediatelyAsKnown = false
-                }
-                knownIssues = append(knownIssues, issue.Key)
-            }
-        }
+		//Check if issue is already know if not set it to alert list and mark as know
+		for _, issue := range issues {
+			if !Util.Contains(knownIssues, issue.Key) {
 
-        if prevNumberOfKnownIssues != len(knownIssues){
-            log.Println("Number of known issues: " + strconv.Itoa(len(knownIssues)))
-        }
+				//Marks the issues as known, without writing an alert.
+				if !markImmediatelyAsKnown {
+					alerts = append(alerts, issue)
+				}
 
-        //Alert for new issues
-        for _, issue := range alerts {
+				knownIssues = append(knownIssues, issue.Key)
+			}
+		}
 
-                message := MatterHook{
-                    Text: ":rotating_light:  **" + issue.Fields.Priority.Name + "** " + issue.Key + " " + issue.Fields.Summary,
-                }
+		markImmediatelyAsKnown = false
 
-                messageJson, _ := json.Marshal(message)
-                req, err := http.NewRequest("POST", cv.WebhookUrl, bytes.NewBuffer(messageJson))
-                req.Header.Set("Content-Type", "application/json")
+		if prevNumberOfKnownIssues != len(knownIssues) {
+			log.Println("Number of known issues: " + strconv.Itoa(len(knownIssues)))
+		}
 
-                matterMostClient := &http.Client{}
+		//Alert for new issues
+		for _, issue := range alerts {
 
-                stopWatch = time.Now()
+			message := MatterHook{
+				Text: ":rotating_light:  **" + issue.Fields.Priority.Name + "** " + issue.Key + " " + issue.Fields.Summary,
+			}
 
-                resp, err := matterMostClient.Do(req)
+			messageJson, _ := json.Marshal(message)
+			req, err := http.NewRequest("POST", cv.WebhookUrl, bytes.NewBuffer(messageJson))
+			req.Header.Set("Content-Type", "application/json")
 
-                stopWatchTimeElapsed = time.Since(stopWatch)
-                mattermostRequestDuration.Observe(float64(stopWatchTimeElapsed.Seconds()))
+			matterMostClient := &http.Client{}
 
-                if err != nil {
-                    panic(err)
-                } else {
-                    mattermostCallsMade.Inc()
-                }
-                defer resp.Body.Close()
-        }
-    }
+			stopWatch = time.Now()
 
-    //Will never be reached!
-    log.Println("The cake is a lie and by the way: You should never have been able to get here! How did you do it?")
-    finished <- true
+			resp, err := matterMostClient.Do(req)
+
+			stopWatchTimeElapsed = time.Since(stopWatch)
+			mattermostRequestDuration.Observe(float64(stopWatchTimeElapsed.Seconds()))
+
+			if err != nil {
+				panic(err)
+			} else {
+				mattermostCallsMade.Inc()
+			}
+			defer resp.Body.Close()
+		}
+	}
+
+	//Will never be reached!
+	log.Println("The cake is a lie and by the way: You should never have been able to get here! How did you do it?")
+	finished <- true
 }


### PR DESCRIPTION
In the default configuration, after startup, an alert for all already existing issues would be send. If the user sets the --NoInitialPost flag, this step now will be skipped.